### PR TITLE
serviceが初期化されずに例外をsnsに投稿しようとしていたため

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -123,8 +123,8 @@ class LambdaService(NamedTuple):
 
 
 def lambda_handler(event, context):
+    service = LambdaService.of(event=event)
     try:
-        service = LambdaService.of(event=event)
         service()
     except Exception as e:
         service.error(e)


### PR DESCRIPTION
UnboundLocalError: local variable 'service' referenced before assignment